### PR TITLE
Globally clip gradient norms by specified maximum norm correctly

### DIFF
--- a/zclip.py
+++ b/zclip.py
@@ -177,7 +177,9 @@ class ZClip:
             self.buffer.append(total_norm)
             if len(self.buffer) >= self.warmup_steps:
                 self._initialize_ema()
-            if self.max_grad_norm is not None:
+            if self.max_grad_norm is not None and is_fsdp_model(model):
+                model.clip_grad_norm_(self.max_grad_norm)
+            elif self.max_grad_norm is not None:
                 torch.nn.utils.clip_grad_norm_(model.parameters(), self.max_grad_norm)
             return total_norm
 


### PR DESCRIPTION
* Globally clips gradient norms by a specified maximum norm value correctly using rank syncing
* See https://docs.pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.FullyShardedDataParallel.clip_grad_norm_