### PR TITLE
Fix lightning callback import. Add grad_clip_fn.

### DIFF
--- a/zclip/__init__.py
+++ b/zclip/__init__.py
@@ -1,5 +1,4 @@
 from zclip.zclip import ZClip, is_fsdp_model
-from zclip.zclip_lightning_callback import ZClipLightningCallback
 
 __all__ = [ZClip, is_fsdp_model]
 


### PR DESCRIPTION
Always errors if lightning is not available. The try method should handle this case.

- Added grad_clip_fn to add our own gradient clip function. Used with the accelerator library which interacts with the model, optimizer. 